### PR TITLE
Fixes Akoma Ntoso link

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -86,7 +86,7 @@ contributors:
     %ul
       %li easy to link to, including directly to parts, chapters and sections
       %li easy to read as HTML webpages
-      %li available as machine-friendly XML in the open #{link_to 'Akoma Ntoso', 'http://akomantoso.org'} format
+      %li available as machine-friendly XML in the open #{link_to 'Akoma Ntoso', 'http://www.akomantoso.org/'} format
       %li freely available from our #{link_to 'Indigo API', 'https://indigo.openbylaws.org.za/api/documents?format=api'}
       %li licensed under a #{link_to 'Creative Commons Attribution 4.0 International License', 'https://creativecommons.org/licenses/by/4.0/'}.
 


### PR DESCRIPTION
Returns `The web server software is running but no content has been added, yet.` if not prefixed with `www`.