### PR TITLE
Points in time

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -72,13 +72,13 @@ def pages_for_act(act)
     expression = act.get_expression(lang.code3)
 
     # full act
-    proxy "#{path}/#{lang.code3}/index.html", "/templates/act/index.html", locals: {act: expression, is_latest: true}, ignore: true
+    proxy "#{path}/#{lang.code3}/index.html", "/templates/act/index.html", locals: {act: expression}, ignore: true
   end
 
   # other expressions
   for expr in act.expressions
     is_latest = expr.expression_date == act.expression_date
-    proxy "#{path}/#{lang.code3}@#{expr.expression_date}/index.html", "/templates/act/index.html", locals: {act: expr, is_latest: is_latest}, ignore: true
+    proxy "#{path}/#{lang.code3}@#{expr.expression_date}/index.html", "/templates/act/index.html", locals: {act: expr}, ignore: true
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -67,11 +67,18 @@ caching_policy 'text/html', max_age: hour
 def pages_for_act(act)
   path = act.frbr_uri.chomp('/')
 
+  # latest expression
   for lang in act.languages
     expression = act.get_expression(lang.code3)
 
     # full act
-    proxy "#{path}/#{lang.code3}/index.html", "/templates/act/index.html", locals: {act: expression}, ignore: true
+    proxy "#{path}/#{lang.code3}/index.html", "/templates/act/index.html", locals: {act: expression, is_latest: true}, ignore: true
+  end
+
+  # other expressions
+  for expr in act.expressions
+    is_latest = expr.expression_date == act.expression_date
+    proxy "#{path}/#{lang.code3}@#{expr.expression_date}/index.html", "/templates/act/index.html", locals: {act: expr, is_latest: is_latest}, ignore: true
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -77,7 +77,6 @@ def pages_for_act(act)
 
   # other expressions
   for expr in act.expressions
-    is_latest = expr.expression_date == act.expression_date
     proxy "#{path}/#{lang.code3}@#{expr.expression_date}/index.html", "/templates/act/index.html", locals: {act: expr}, ignore: true
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -65,19 +65,25 @@ caching_policy 'text/html', max_age: hour
 # Website pages
 
 def pages_for_act(act)
-  path = act.frbr_uri.chomp('/')
-
-  # latest expression
-  for lang in act.languages
-    expression = act.get_expression(lang.code3)
-
-    # full act
-    proxy "#{path}/#{lang.code3}/index.html", "/templates/act/index.html", locals: {act: expression}, ignore: true
+  if act.stub
+    expressions = [act]
+  else
+    # expressions at the latest date
+    date = act.points_in_time[-1].date
+    expressions = act.expressions.filter { |x| x.expression_date = date }
   end
 
-  # other expressions
+  # pages for the expressions at the latest point in time
+  for expr in expressions
+    # full act
+    path = act.frbr_uri.chomp('/')
+    proxy "#{path}/#{expr.language}/index.html", "/templates/act/index.html", locals: {act: expr}, ignore: true
+  end
+
+  # older expressions
   for expr in act.expressions
-    proxy "#{path}/#{lang.code3}@#{expr.expression_date}/index.html", "/templates/act/index.html", locals: {act: expr}, ignore: true
+    path = expr.expression_frbr_uri.chomp('/')
+    proxy "#{path}/index.html", "/templates/act/index.html", locals: {act: expr}, ignore: true
   end
 end
 

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -214,7 +214,10 @@ class IndigoDocument < IndigoComponent
         @events << HistoryEvent.new(repeal.date, :repeal, repeal)
       end
 
-      @events.sort_by! { |e| e.date }.reverse!
+      @events = @events.group_by(&:date).to_a
+
+      # turn into pairs, sorted by descending date
+      @events.sort_by! { |x| x[0] }.reverse!
     end
 
     @events

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -271,6 +271,10 @@ class IndigoDocument < IndigoComponent
     }.flatten
   end
 
+  def latest_expression?
+    return stub || (self.expression_date == self.points_in_time[-1].date)
+  end
+
   protected
   def parse_toc(items)
     items.map do |item|

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -399,8 +399,8 @@ class IndigoMiddlemanExtension < ::Middleman::Extension
       resources.append(res)
     end
 
-    # include attachments
-    for attachment in expr.attachments
+    # include image attachments
+    for attachment in expr.attachments.filter { |a| a.mime_type.start_with?('image/') }
       target = "#{path}/media/#{attachment.filename}"
       source = app.source_dir.to_s + "/../downloads/media-" + target.gsub("/", "-")
 

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -256,6 +256,17 @@ class IndigoDocument < IndigoComponent
     end
   end
 
+  # Try to get an expression at a date a language, falling back to
+  # any language if necessary.
+  def get_best_expression(language, date)
+    candidates = expressions.select { |x| x.expression_date == date }
+    expr = candidates.select { |x| x.language == language }
+    return expr.first if expr.size > 0
+
+    # no matching language, just use the first one
+    return candidates.first
+  end
+
   def expressions
     return [] if stub
 
@@ -275,16 +286,9 @@ class IndigoDocument < IndigoComponent
     return stub || (expression_date == points_in_time[-1].date)
   end
 
+  # Latest expression for this work, trying to match on current language
   def latest_expression
-    latest_date = points_in_time[-1].date
-    candidates = expressions.select { |x| x.expression_date == latest_date }
-
-    # try to find current language match
-    expr = candidates.select { |x| x.language == language }
-    return expr.first if expr
-
-    # no matching language, just use the first one
-    return candidates.first
+    get_best_expression(language, points_in_time[-1].date)
   end
 
   def next_pit_date

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -214,7 +214,7 @@ class IndigoDocument < IndigoComponent
         @events << HistoryEvent.new(repeal.date, :repeal, repeal)
       end
 
-      @events.sort_by! { |e| e.date }
+      @events.sort_by! { |e| e.date }.reverse!
     end
 
     @events
@@ -272,7 +272,27 @@ class IndigoDocument < IndigoComponent
   end
 
   def latest_expression?
-    return stub || (self.expression_date == self.points_in_time[-1].date)
+    return stub || (expression_date == points_in_time[-1].date)
+  end
+
+  def latest_expression
+    latest_date = points_in_time[-1].date
+    candidates = expressions.select { |x| x.expression_date == latest_date }
+
+    # try to find current language match
+    expr = candidates.select { |x| x.language == language }
+    return expr.first if expr
+
+    # no matching language, just use the first one
+    return candidates.first
+  end
+
+  def next_pit_date
+    # date of next point in time after this one.
+    ix = points_in_time.index { |p| p.date == expression_date } + 1
+    if ix < points_in_time.size
+      points_in_time[ix].date - 1
+    end
   end
 
   protected

--- a/lib/indigo.rb
+++ b/lib/indigo.rb
@@ -304,10 +304,6 @@ class IndigoDocument < IndigoComponent
 end
 
 class IndigoAttachment < IndigoComponent
-  def local_url
-    # TODO: LANG
-    @parent.frbr_uri + "/media/" + filename
-  end
 end
 
 # document collection loaded from Indigo

--- a/source/css/_site.scss
+++ b/source/css/_site.scss
@@ -59,6 +59,10 @@ h1, h2, h3, h4, h5, .h1, .h2, .h3, .h4, .h5 {
       }
     }
 
+    h2 {
+      font-size: 19px;
+    }
+
     .breadcrumbs {
       @media print { display: none }
 

--- a/source/css/bylaw.css.scss
+++ b/source/css/bylaw.css.scss
@@ -34,10 +34,6 @@
 }
 
 .downloads {
-  .download {
-    margin-bottom: 30px;
-  }
-
   .btn {
     margin-left: 10px;
   }

--- a/source/layouts/bylaw.haml
+++ b/source/layouts/bylaw.haml
@@ -5,6 +5,7 @@
 
     %meta(property="og:type" content="article")
     %meta{property: "og:url", content: act_url(act, external: true)}
+    %link{rel: "canonical", href: "https://openbylaws.org.za" + act.frbr_uri + "/eng/"}
 
   - content_for :meta_description do
     #{act.title} for #{regions[act.locality].name}

--- a/source/templates/act/_header.html.haml
+++ b/source/templates/act/_header.html.haml
@@ -5,6 +5,10 @@
 %h1
   %a{href: act_url(act)}&= act.title
 
-- if not act.stub and not act.latest_expression?
+- if not act.stub and act.points_in_time.size > 1
   %h2.pt-1
-    as from #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}
+    as from #{act.expression_date.strftime("%e %B %Y")}
+    - if act.latest_expression?
+      onwards
+    - else
+      to #{act.next_pit_date.strftime("%e %B %Y")}

--- a/source/templates/act/_header.html.haml
+++ b/source/templates/act/_header.html.haml
@@ -7,5 +7,4 @@
 
 - if not act.stub and not act.latest_expression?
   %h2.pt-1
-    as at
-    &= act.expression_date
+    as from #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}

--- a/source/templates/act/_header.html.haml
+++ b/source/templates/act/_header.html.haml
@@ -4,3 +4,8 @@
 
 %h1
   %a{href: act_url(act)}&= act.title
+
+- if not act.stub and not act.latest_expression?
+  %h2.pt-1
+    as at
+    &= act.expression_date

--- a/source/templates/act/_header.html.haml
+++ b/source/templates/act/_header.html.haml
@@ -4,6 +4,8 @@
 
 %h1
   %a{href: act_url(act)}&= act.title
+  - if act.repealed?
+    %span.badge.badge-danger repealed
 
 - if not act.stub and act.points_in_time.size > 1
   %h2.pt-1

--- a/source/templates/act/_notices.html.haml
+++ b/source/templates/act/_notices.html.haml
@@ -1,27 +1,24 @@
 #notices
   - if act.repealed?
-    .alert.alert-warning
+    .alert.alert-danger
       %h5 Repealed
       This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
       #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
 
   - if not act.stub
     - if act.latest_expression?
-      - if act.repealed?
-        .alert.alert-info
-          This is the latest version of this by-law up to when it was repealed.
-
-      - else
-        .alert.alert-info
-          This is the latest version of this by-law and is the version currently in force.
+      .alert.alert-info
+        - if act.repealed?
+          This is the version of this by-law as it was when it was repealed.
+        - else
+          This is the latest version of this by-law.
 
     - elsif act.points_in_time.length > 1
       .alert.alert-warning
         This is the version of this by-law as it was from
         #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}.
-        Read the
         %a{href: act.frbr_uri + "/eng/"}
           - if act.repealed?
-            latest version.
+            Read it as it was when it was repealed.
           - else
-            latest version currently in force.
+            Read the version currently in force.

--- a/source/templates/act/_notices.html.haml
+++ b/source/templates/act/_notices.html.haml
@@ -2,20 +2,26 @@
   - if act.repealed?
     .alert.alert-warning
       %h4 Repealed
-      %p
-        This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
-        #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
+      This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
+      #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
 
   - if not act.stub
     - if act.latest_expression?
-      - if not act.repealed?
+      - if act.repealed?
+        .alert.alert-info
+          This is the latest version of this by-law up to when it was repealed.
+
+      - else
         .alert.alert-info
           This is the latest version of this by-law and is the version currently in force.
 
     - elsif act.points_in_time.length > 1
       .alert.alert-warning
         This is the version of this by-law as it was from
-        %b #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}.
+        #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}.
         Read the
         %a{href: act.frbr_uri + "/eng/"}
-          latest version currently in force.
+          - if act.repealed?
+            latest version.
+          - else
+            latest version currently in force.

--- a/source/templates/act/_notices.html.haml
+++ b/source/templates/act/_notices.html.haml
@@ -1,7 +1,7 @@
 #notices
   - if act.repealed?
     .alert.alert-warning
-      %h4 Repealed
+      %h5 Repealed
       This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
       #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
 

--- a/source/templates/act/_notices.html.haml
+++ b/source/templates/act/_notices.html.haml
@@ -5,3 +5,7 @@
       %p
         This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
         #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
+
+  - if not act.repealed? and not act.stub and act.latest_expression?
+    .alert.alert-info
+      This is the latest version of this by-law and is the version currently in force.

--- a/source/templates/act/_notices.html.haml
+++ b/source/templates/act/_notices.html.haml
@@ -6,6 +6,16 @@
         This by-law was repealed on #{act.repeal.date.strftime('%e %B %Y')} by
         #{link_to act.repeal.repealing_title, act.repeal.repealing_uri + '/eng'}.
 
-  - if not act.repealed? and not act.stub and act.latest_expression?
-    .alert.alert-info
-      This is the latest version of this by-law and is the version currently in force.
+  - if not act.stub
+    - if act.latest_expression?
+      - if not act.repealed?
+        .alert.alert-info
+          This is the latest version of this by-law and is the version currently in force.
+
+    - elsif act.points_in_time.length > 1
+      .alert.alert-warning
+        This is the version of this by-law as it was from
+        %b #{act.expression_date.strftime("%e %B %Y")} to #{act.next_pit_date.strftime("%e %B %Y")}.
+        Read the
+        %a{href: act.frbr_uri + "/eng/"}
+          latest version currently in force.

--- a/source/templates/act/_resources.html.haml
+++ b/source/templates/act/_resources.html.haml
@@ -6,9 +6,14 @@
 
         .timeline
           %ul.list-unstyled.timeline-items
-            - for event in act.history
+            - for event in act.latest_expression.history
               %li
-                %h5&= event.date.strftime("%e %B %Y")
+                %h5
+                  &= event.date.strftime("%e %B %Y")
+                  - if event.date == act.expression_date
+                    %span.badge.badge-info this version
+                  - elsif event.date == act.latest_expression.expression_date
+                    %span.badge.badge-info latest version
 
                 - case event.event
                 - when :amendment

--- a/source/templates/act/_resources.html.haml
+++ b/source/templates/act/_resources.html.haml
@@ -1,49 +1,49 @@
-.downloads.mt-3
+.mt-3
   .row
-    .col-sm-8
-      .download
-        %h3 History of this by-law
+    .col-sm-8.mb-3
+      %h3 History of this by-law
 
-        .timeline
-          %ul.list-unstyled.timeline-items
-            - for event in act.latest_expression.history
-              %li
-                %h5
-                  &= event.date.strftime("%e %B %Y")
-                  - if event.date == act.expression_date
-                    %span.badge.badge-info this version
-                  - elsif event.date == act.latest_expression.expression_date
-                    %span.badge.badge-info latest version
+      .timeline
+        %ul.list-unstyled.timeline-items
+          - for date, events in act.latest_expression.history
+            %li
+              %h5
+                &= date.strftime("%e %B %Y")
+                - if date == act.expression_date
+                  %span{class: act.latest_expression? ? "badge badge-info" : "badge badge-warning"} this version
 
-                - case event.event
-                - when :amendment
-                  Amended by
-                  %a{href: event.info.amending_uri + '/eng'}
-                    %i&= event.info.amending_title
 
-                - when :assent
-                  Assented to by council.
+              - for event in events
+                %div
+                  - case event.event
+                  - when :amendment
+                    Amended by
+                    %a{href: event.info.amending_uri + '/eng'}
+                      %i&= event.info.amending_title
 
-                - when :commencement
-                  By-law commences.
+                  - when :assent
+                    Assented to by council.
 
-                - when :publication
-                  Published in 
-                  %a{href: act.publication_document.url}
-                    #{act.full_publication}
+                  - when :commencement
+                    By-law commences.
 
-                - when :repeal
-                  Repealed by
-                  %a{href: event.info.repealing_uri + '/eng'}
-                    %i&= event.info.repealing_title
+                  - when :publication
+                    Published in 
+                    %a{href: act.publication_document.url}
+                      #{act.full_publication}
 
-                - expr = act.get_best_expression(act.language, event.date)
+                  - when :repeal
+                    Repealed by
+                    %a{href: event.info.repealing_uri + '/eng'}
+                      %i&= event.info.repealing_title
+
+              - if date != act.expression_date
+                - expr = act.get_best_expression(act.language, date)
                 - if expr
-                  .pt-2
-                    %a{href: expr.expression_frbr_uri} Read this version
+                  %a.btn.btn-outline-primary.mt-2{href: expr.expression_frbr_uri} Read this version
 
     .col-sm-4
-      .download
+      .downloads.mb-3
         %h3 Download for later
 
         %p

--- a/source/templates/act/_resources.html.haml
+++ b/source/templates/act/_resources.html.haml
@@ -37,6 +37,11 @@
                   %a{href: event.info.repealing_uri + '/eng'}
                     %i&= event.info.repealing_title
 
+                - expr = act.get_best_expression(act.language, event.date)
+                - if expr
+                  .pt-2
+                    %a{href: expr.expression_frbr_uri} Read this version
+
     .col-sm-4
       .download
         %h3 Download for later

--- a/source/templates/act/_resources.html.haml
+++ b/source/templates/act/_resources.html.haml
@@ -1,4 +1,3 @@
-
 .downloads.mt-3
   .row
     .col-sm-8

--- a/source/templates/act/_support_download_button.html.haml
+++ b/source/templates/act/_support_download_button.html.haml
@@ -1,3 +1,0 @@
-%i.fa.fa-fw.fa-download
-%a{href: file.local_url}
-  Download #{File.extname(file.filename)[1..-1].upcase} (#{number_to_human_size(file['size'])})


### PR DESCRIPTION
* generate points in time pages
* link to those pages in the history
* tell Google that the canonical page is the most recent one, so that there aren't duplicate Google search results
* show notices to help users understand what's going on

# In-force by-laws

## One point in time

<img width="979" alt="Air Pollution Control 2020-02-13 10-02-00" src="https://user-images.githubusercontent.com/4178542/74413360-e9c70400-4e47-11ea-9b1a-d75cde5e08f6.png">

<img width="629" alt="Air Pollution Control 2020-02-13 10-02-27" src="https://user-images.githubusercontent.com/4178542/74413379-f51a2f80-4e47-11ea-96a1-fa1855a6b445.png">

## Multiple points in time

### Latest point in time

<img width="586" alt="Public Road and Miscellaneous 2020-02-13 10-02-58" src="https://user-images.githubusercontent.com/4178542/74413415-095e2c80-4e48-11ea-81b5-9658186a60eb.png">

<img width="632" alt="Public Road and Miscellaneous 2020-02-13 10-04-44" src="https://user-images.githubusercontent.com/4178542/74413543-475b5080-4e48-11ea-9bda-157289ca3e34.png">


### Older point in time

<img width="956" alt="Public Road and Miscellaneous 2020-02-13 10-03-40" src="https://user-images.githubusercontent.com/4178542/74413464-209d1a00-4e48-11ea-9aaa-f09481bc0c75.png">

<img width="640" alt="Public Road and Miscellaneous 2020-02-13 10-04-09" src="https://user-images.githubusercontent.com/4178542/74413507-3579ad80-4e48-11ea-938c-8dcd205a2a7b.png">


# Repealed by-laws

## Single point in time

<img width="633" alt="Outdoor Advertising 2020-02-13 10-05-20" src="https://user-images.githubusercontent.com/4178542/74413590-5f32d480-4e48-11ea-85e1-1079883ab6dc.png">

## Multiple points in time.

I don't have an example of this. It will show a similar message to the un-repealed version.